### PR TITLE
Changed rules for statement separators in migration scripts

### DIFF
--- a/src/Database/Persist/Schema/Migrations/Persist.hs
+++ b/src/Database/Persist/Schema/Migrations/Persist.hs
@@ -12,14 +12,14 @@ module Database.Persist.Schema.Migrations.Persist
 
 import Control.Monad (when)
 import Control.Monad.IO.Class
-import Data.List.Split (endBy)
+import Data.List.Split (splitWhen)
 import Data.Maybe
 import Database.Persist
 import Database.Persist.Sql hiding (Migration)
-import Data.Text hiding (map)
 import Text.Shakespeare.Text
 import Database.Schema.Migrations.Migration (Migration(..), newMigration)
 import Database.Schema.Migrations.Backend (rootMigrationName)
+import qualified Data.Text as T
 
 migrationTableName :: String
 migrationTableName = "installed_migrations"
@@ -30,32 +30,38 @@ migrationIdColName = "migration_id"
 getBootstrapMigration :: SqlPersistM Migration
 getBootstrapMigration = do
   let m = newMigration rootMigrationName
-  return $ m { mApply = unpack [st|CREATE TABLE #{migrationTableName} (#{migrationIdColName} TEXT)|]
-             , mRevert = Just $ unpack [st|DROP TABLE #{migrationTableName}|]
+  return $ m { mApply = T.unpack [st|CREATE TABLE #{migrationTableName} (#{migrationIdColName} TEXT)|]
+             , mRevert = Just $ T.unpack [st|DROP TABLE #{migrationTableName}|]
              , mDesc = Just "Migration table installation"
              }
 
 isBootstrapped :: SqlPersistM Bool
 isBootstrapped = do
   -- This request will work only for MSSQL
-  res <- rawSql "SELECT table_name FROM information_schema.tables" [] >>= return . map unSingle
-  return $ elem (pack migrationTableName) res
+  res <- map unSingle <$> rawSql "SELECT table_name FROM information_schema.tables" []
+  return $ elem (T.pack migrationTableName) res
 
 applyMigration :: Migration -> SqlPersistM ()
 applyMigration m = do
-  let queryList = endBy ";" (mApply m)
-  mapM (\q -> rawExecute (pack q) []) queryList
+  let queryList = splitStatements $ mApply m
+  mapM_ (\q -> rawExecute q []) queryList
   rawExecute [st|INSERT INTO #{migrationTableName} (#{migrationIdColName}) VALUES (?)|] [toPersistValue (mId m)]
 
 revertMigration :: Migration -> SqlPersistM ()
 revertMigration m = do
   let revert = mRevert m
   when (isJust revert) $ do
-    let queryList = endBy ";" (fromJust revert)
-    mapM (\q -> rawExecute (pack q) []) queryList
+    let queryList = splitStatements $ fromJust revert
+    mapM_ (\q -> rawExecute q []) queryList
     return ()
   rawExecute [st|DELETE FROM #{migrationTableName} WHERE #{migrationIdColName} = ?|] [toPersistValue (mId m)]
 
+splitStatements :: String -> [T.Text]
+splitStatements = map T.unlines . splitWhen isSeparator . T.lines . T.pack
+  where isSeparator x =
+          let stripped = T.strip x
+          in  stripped == ";" || stripped == "GO"
+
 getMigrations :: SqlPersistM [String]
 getMigrations =
-  rawSql [st|SELECT #{migrationIdColName} FROM #{migrationTableName}|] [] >>= return . map unSingle
+  map unSingle <$> rawSql [st|SELECT #{migrationIdColName} FROM #{migrationTableName}|] []


### PR DESCRIPTION
Now "GO" or ";" (single semicolon) lines are recognized as statement separators. Previously statements were separated on lines ending with ";", which didn't let me to define triggers for PostgreSQL.
